### PR TITLE
`yarn:build:webpack` -> `yarn build:webpack`

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "package": "electron-builder ...",
     "build:graphql-codegen": "graphql-codegen --config graphql-codegen.yml",
     "build:webpack": "webpack --config webpack/webpack.config.js",
-    "build": "yarn build:graphql-codegen && yarn:build:webpack",
+    "build": "yarn build:graphql-codegen && yarn build:webpack",
     "start": "electron .",
     "types": "tsc --noEmit -p tsconfig.json",
     "lint": "eslint --cache .",


### PR DESCRIPTION
Alternatively, you could use the concurrently package's "run sequentially and also fail if either command fails" feature.